### PR TITLE
depend on concurrent-ruby ~> 1.0.0

### DIFF
--- a/hermann.gemspec
+++ b/hermann.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
 
   if RUBY_PLATFORM == "java"
     s.files << 'lib/hermann_jars.rb'
-    s.add_dependency 'concurrent-ruby', '~> 0.7.0'
+    s.add_dependency 'concurrent-ruby', '~> 1.0.0'
 
     # IMPORTANT: make sure that jar-dependencies is only a development
     # dependency of your gem. if it is a runtime dependencies the require_jars

--- a/lib/hermann/producer.rb
+++ b/lib/hermann/producer.rb
@@ -102,7 +102,8 @@ module Hermann
         @children.each do |child|
           # Skip over any children that should already be reaped for other
           # reasons
-          next if child.completed?
+          next if (Hermann.jruby? ? child.fulfilled? : child.completed?)
+
           # Propagate errors to the remaining children
           child.internal_set_error(ex)
         end
@@ -118,7 +119,7 @@ module Hermann
       # Filter all children who are no longer pending/fulfilled
       total_children = @children.size
 
-      @children = @children.reject { |c| c.completed? }
+      @children = @children.reject { |c| Hermann.jruby? ? c.fulfilled? : c.completed? }
 
       return (total_children - children.size)
     end


### PR DESCRIPTION
opening a PR to see what does Travis think about this change.

see issue #131 