### PR TITLE
Locked rake version to ~11.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 group :development do
   gem 'jbundler', :platform => :jruby
-  gem 'rake'
+  gem 'rake', '~> 11.3.0'
   gem 'i18n', '~> 0.6.11', :platform => :mri_18
   gem 'activesupport', '~> 3.x', :platform => :mri_18
   gem 'ruby-maven', '~> 3.1.1.0', :platform => :jruby


### PR DESCRIPTION
@rtyler 
Rake 12.0 replaced "last_comment" with "last_description".  

This describes the issue and possible fix:
http://stackoverflow.com/questions/35893584/nomethoderror-undefined-method-last-comment-after-upgrading-to-rake-11

Rather than upgrade rspec to 3.5.x and risk changes to test behavior, I've locked rake to the last version before 12.0.